### PR TITLE
Fix "cannot bind non-const lvalue reference of type ‘ImVec4&’ to an rvalue of type ‘ImVec4’" compilation error

### DIFF
--- a/wkbre.cpp
+++ b/wkbre.cpp
@@ -1897,7 +1897,7 @@ bool IGGSLItemsGetter(void *data, int idx, const char **out)
 	return true;
 }
 
-bool OldColorButton(const char *desc, ImVec4 &col, bool mini = false)
+bool OldColorButton(const char *desc, const ImVec4 &col, bool mini = false)
 {
 	float tlh = ImGui::GetTextLineHeight();
 	return ImGui::ColorButton(desc, col, ImGuiColorEditFlags_NoTooltip, mini ? ImVec2(tlh,tlh) : ImVec2(0,0));


### PR DESCRIPTION
This patch fixes the following compilation error on GCC 12 of the MinGW-w64 toolchain:

```
wkbre/wkbre.cpp: In function ‘bool IGPlayerChooser(char*, goref*)’:
wkbre/wkbre.cpp:2404:41: error: cannot bind non-const lvalue reference of type ‘ImVec4&’ to an rvalue of type ‘ImVec4’
 2404 |                 OldColorButton("color", ImVec4(1, 1, 1, 1));
      |                                         ^~~~~~~~~~~~~~~~~~
wkbre/wkbre.cpp:1900:47: note:   initializing argument 2 of ‘bool OldColorButton(const char*, ImVec4&, bool)’
 1900 | bool OldColorButton(const char *desc, ImVec4 &col, bool mini = false)
      |                                       ~~~~~~~~^~~
```

~~as the pass-by-reference syntax doesn't seem to be necessary~~.  I have little to no C++/Dear ImGui experience so feel free to close this if it's not the case.